### PR TITLE
Feature: Switch from logback to log4j2 with AsyncLogger.

### DIFF
--- a/buildNumber.properties
+++ b/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Sat Dec 03 21:52:54 ICT 2022
-buildNumber=5
+#Sat Dec 10 22:18:52 ICT 2022
+buildNumber=25

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,6 +68,16 @@
 			<artifactId>buildnumber-maven-plugin</artifactId>
 			<version>3.0.0</version>
 			<type>maven-plugin</type>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-log4j2</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.lmax</groupId>
+			<artifactId>disruptor</artifactId>
+			<version>3.4.4</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/src/main/resources/log4j2.component.properties
+++ b/src/main/resources/log4j2.component.properties
@@ -1,0 +1,1 @@
+log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG">
+  <Appenders>
+    <Console name="LogToConsole" target="SYSTEM_OUT">
+      <JSONLayout complete="false" compact="true" eventEol="true" />
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="com.thailb" level="debug" additivity="false">
+      <AppenderRef ref="LogToConsole"/>
+    </Logger>
+    <Logger name="org.springframework.boot" level="error" additivity="false">
+      <AppenderRef ref="LogToConsole"/>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="LogToConsole"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF">
+  <Appenders>
+    <Console name="LogToConsole" target="SYSTEM_OUT">
+      <JSONLayout complete="false" compact="true" eventEol="true" />
+    </Console>
+  </Appenders>
+  <Loggers>
+    <AsyncLogger name="com.thailb" level="debug" additivity="false">
+      <AppenderRef ref="LogToConsole"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.springframework.boot" level="error" additivity="false">
+      <AppenderRef ref="LogToConsole"/>
+    </AsyncLogger>
+    <Root level="error">
+      <AppenderRef ref="LogToConsole"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-  <include resource="org/springframework/boot/logging/logback/base.xml" />
-  <logger name="org.springframework" level="ERROR"/>
-</configuration>


### PR DESCRIPTION
* Remove `logback` from JPA Mongo Data.
* Add `log4j2` as the log provider.
* Apply JSONLayout instead of classic layout.